### PR TITLE
Add database support

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: '8.3'
           coverage: none
 
       - name: Install composer dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -17,12 +17,12 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, windows-latest]
-        php: [8.3, 8.2, 8.1]
-        laravel: [10.*]
+        php: [8.3]
+        laravel: [11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
             carbon: ^2.63
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "illuminate/contracts": "^10.0||^11.0",
         "laravel/folio": "^v1.0",
         "laravel/prompts": "^0.1",
+        "laravel/scout": "^v10.9",
         "tempest/highlight": "2.0"
     },
     "require-dev": {

--- a/config/docsidian.php.stub
+++ b/config/docsidian.php.stub
@@ -2,17 +2,11 @@
 
 return [
     'installed' => true,
-    // You can define as many documentation sites as you want below. Just make sure that each has unique paths and uri.
-    'sites' => [
-        'default' => [
-            'default_visibility' => '{{ default_visibility }}',
-            'folio_middleware' => ['web'],
-            'folio_path' => resource_path('{{ folio_path }}'),
-            'folio_uri' => '{{ folio_uri }}',
-            'layout' => 'docsidian',
-            'md_path' => base_path('{{ md_path }}'),
-            'md_repo' => 'artisan-build/docsidian-docs', // Only applies to hosted docs
-        ],
-    ],
-
+    'default_visibility' => '{{ default_visibility }}',
+    'folio_middleware' => ['web'],
+    'folio_path' => resource_path('{{ folio_path }}'),
+    'folio_uri' => '{{ folio_uri }}',
+    'layout' => 'docsidian',
+    'md_path' => base_path('{{ md_path }}'),
+    'obsidian_config' => base_path('{{ md_path }}/.obsidian')
 ];

--- a/database/factories/DocsidianPageFactory.php
+++ b/database/factories/DocsidianPageFactory.php
@@ -2,12 +2,13 @@
 
 namespace ArtisanBuild\Docsidian\Database\Factories;
 
+use ArtisanBuild\Docsidian\Models\DocsidianPage;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-/*
-class ModelFactory extends Factory
+
+class DocsidianPageFactory extends Factory
 {
-    protected $model = YourModel::class;
+    protected $model = DocsidianPage::class;
 
     public function definition()
     {
@@ -16,4 +17,3 @@ class ModelFactory extends Factory
         ];
     }
 }
-*/

--- a/database/factories/DocsidianPageFactory.php
+++ b/database/factories/DocsidianPageFactory.php
@@ -5,7 +5,6 @@ namespace ArtisanBuild\Docsidian\Database\Factories;
 use ArtisanBuild\Docsidian\Models\DocsidianPage;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-
 class DocsidianPageFactory extends Factory
 {
     protected $model = DocsidianPage::class;

--- a/database/factories/DocsidianSiteFactory.php
+++ b/database/factories/DocsidianSiteFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Database\Factories;
+
+use ArtisanBuild\Docsidian\Models\DocsidianSite;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+
+class DocsidianSiteFactory extends Factory
+{
+    protected $model = DocsidianSite::class;
+
+    public function definition()
+    {
+        return [
+
+        ];
+    }
+}

--- a/database/factories/DocsidianSiteFactory.php
+++ b/database/factories/DocsidianSiteFactory.php
@@ -5,7 +5,6 @@ namespace ArtisanBuild\Docsidian\Database\Factories;
 use ArtisanBuild\Docsidian\Models\DocsidianSite;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
-
 class DocsidianSiteFactory extends Factory
 {
     protected $model = DocsidianSite::class;

--- a/database/migrations/create_docsidian_table.php.stub
+++ b/database/migrations/create_docsidian_table.php.stub
@@ -1,5 +1,7 @@
 <?php
 
+use ArtisanBuild\Docsidian\Models\DocsidianSite;
+use ArtisanBuild\Docsidian\SiteStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -8,11 +10,39 @@ return new class extends Migration
 {
     public function up()
     {
-        Schema::create('docsidian_table', function (Blueprint $table) {
+        Schema::create('docsidian_sites', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('description')->nullable();
+            $table->string('image')->nullable();
+            $table->unsignedInteger('weight')->nullable();
+            $table->string('status')->default(SiteStatus::Hidden->name);
+            $table->string('default_visibility')->default('public');
+            $table->json('folio_middleware');
+            $table->string('folio_path');
+            $table->string('folio_uri');
+            $table->string('layout');
+            $table->string('md_path');
+            $table->string('obsidian_config');
 
-            // add fields
+            /*
+             * 'folio_middleware' => ['web'],
+            'folio_path' => resource_path('views/docs'),
+            'folio_uri' => 'docs',
+            'layout' => 'docsidian',
+            'md_path' => base_path('documentation'),
+            'md_repo' => 'artisan-build/docsidian-docs',
+             */
+            $table->timestamps();
+        });
 
+        Schema::create('docsidian_pages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignIdFor(DocsidianSite::class);
+            $table->string('uri');
+            $table->text('public')->nullable();
+            $table->text('protected')->nullable();
+            $table->text('private')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/create_docsidian_table.php.stub
+++ b/database/migrations/create_docsidian_table.php.stub
@@ -24,15 +24,6 @@ return new class extends Migration
             $table->string('layout');
             $table->string('md_path');
             $table->string('obsidian_config');
-
-            /*
-             * 'folio_middleware' => ['web'],
-            'folio_path' => resource_path('views/docs'),
-            'folio_uri' => 'docs',
-            'layout' => 'docsidian',
-            'md_path' => base_path('documentation'),
-            'md_repo' => 'artisan-build/docsidian-docs',
-             */
             $table->timestamps();
         });
 

--- a/src/Commands/DiscoverCommand.php
+++ b/src/Commands/DiscoverCommand.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Str;
 class DiscoverCommand extends Command
 {
     public $signature = 'docsidian:discover {directory?}';
+
     public $description = 'Create a record for every folder in the markdown folder';
 
     public function handle(): int
@@ -42,6 +43,7 @@ class DiscoverCommand extends Command
 
             $this->info("Created record for {$key}");
         }
+
         return self::SUCCESS;
     }
 

--- a/src/Commands/DiscoverCommand.php
+++ b/src/Commands/DiscoverCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Commands;
+
+use ArtisanBuild\Docsidian\Models\DocsidianSite;
+use ArtisanBuild\Docsidian\SiteStatus;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class DiscoverCommand extends Command
+{
+    public $signature = 'docsidian:discover {directory?}';
+    public $description = 'Create a record for every folder in the markdown folder';
+
+    public function handle(): int
+    {
+        $directories = File::directories($this->argument('directory') ?? config('docsidian.md_path'));
+
+        foreach ($directories as $directory) {
+            if (DocsidianSite::where('md_path', $directory)->exists()) {
+                continue;
+            }
+            $key = last(explode(DIRECTORY_SEPARATOR, $directory));
+            $site = DocsidianSite::create([
+                'name' => $this->generateName($key),
+                'description' => null,
+                'image' => null,
+                'weight' => (DocsidianSite::max('weight') ?? 0) + 100,
+                'status' => SiteStatus::Hidden,
+                'default_visibility' => config('docsidian.default_visibility'),
+                'folio_middleware' => config('docsidian.folio_middleware'),
+                'folio_path' => implode(DIRECTORY_SEPARATOR, [config('docsidian.folio_path'), $key]),
+                'folio_uri' => implode('/', [config('docsidian.folio_uri'), $key]),
+                'layout' => config('docsidian.layout'),
+                'md_path' => $directory,
+                'obsidian_config' => config('docsidian.obsidian_config'),
+
+            ]);
+
+            File::ensureDirectoryExists($site->folio_path);
+
+            $this->info("Created record for {$key}");
+        }
+        return self::SUCCESS;
+    }
+
+    public function generateName(string $key): string
+    {
+        if (str_contains('.', $key)) {
+            return $key;
+        }
+
+        return Str::headline($key);
+    }
+}

--- a/src/Commands/GenerateCommand.php
+++ b/src/Commands/GenerateCommand.php
@@ -19,6 +19,7 @@ use ArtisanBuild\Docsidian\Contracts\HighlightsCodeBlocks;
 use ArtisanBuild\Docsidian\Contracts\IndexesSiteForSearch;
 use ArtisanBuild\Docsidian\DocumentationSite;
 use ArtisanBuild\Docsidian\EmbeddedMedia;
+use ArtisanBuild\Docsidian\Models\DocsidianSite;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Pipeline;
@@ -31,8 +32,10 @@ class GenerateCommand extends Command
 
     public function handle(): int
     {
-        foreach (config('docsidian.sites') as $key => $site) {
-            $this->info("Generating {$key}");
+        foreach (DocsidianSite::all() as $site) {
+            $this->info("Generating {$site->name}");
+
+            $site = $site->toArray();
 
             File::deleteDirectory($site['folio_path']);
             File::ensureDirectoryExists($site['folio_path']);

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -54,8 +54,8 @@ class InstallCommand extends Command
 
         File::put(config_path('docsidian.php'), $configContents);
 
-        $this->callSilently("vendor:publish", [
-            '--tag' => "docsidian-migrations",
+        $this->callSilently('vendor:publish', [
+            '--tag' => 'docsidian-migrations',
         ]);
 
         $this->call('migrate');

--- a/src/Commands/InstallCommand.php
+++ b/src/Commands/InstallCommand.php
@@ -48,11 +48,17 @@ class InstallCommand extends Command
 
         $configContents = File::get(__DIR__.'/../../config/docsidian.php.stub');
 
-        foreach (['md_path', 'folio_uri', 'folio_path'] as $key) {
+        foreach (['default_visibility', 'md_path', 'folio_uri', 'folio_path'] as $key) {
             $configContents = str_replace("{{ $key }}", $config[$key], $configContents);
         }
 
         File::put(config_path('docsidian.php'), $configContents);
+
+        $this->callSilently("vendor:publish", [
+            '--tag' => "docsidian-migrations",
+        ]);
+
+        $this->call('migrate');
 
         return self::SUCCESS;
     }

--- a/src/DocsidianServiceProvider.php
+++ b/src/DocsidianServiceProvider.php
@@ -14,7 +14,6 @@ use ArtisanBuild\Docsidian\Models\DocsidianSite;
 use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Blade;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Schema;
 use Laravel\Folio\Folio;

--- a/src/DocsidianServiceProvider.php
+++ b/src/DocsidianServiceProvider.php
@@ -70,9 +70,6 @@ class DocsidianServiceProvider extends PackageServiceProvider
                 ->middleware($site->folio_middleware);
         }
 
-
-
-
         if (app(GetDefinedAbilities::class)()->isEmpty()) {
             Gate::define('docsidian-public', fn (?Authenticatable $user) => true);
             Gate::define('docsidian-protected', fn (?Authenticatable $user) => $user instanceof Authenticatable);

--- a/src/DocsidianServiceProvider.php
+++ b/src/DocsidianServiceProvider.php
@@ -70,6 +70,9 @@ class DocsidianServiceProvider extends PackageServiceProvider
                 ->middleware($site->folio_middleware);
         }
 
+
+
+
         if (app(GetDefinedAbilities::class)()->isEmpty()) {
             Gate::define('docsidian-public', fn (?Authenticatable $user) => true);
             Gate::define('docsidian-protected', fn (?Authenticatable $user) => $user instanceof Authenticatable);

--- a/src/DocsidianServiceProvider.php
+++ b/src/DocsidianServiceProvider.php
@@ -5,13 +5,18 @@ namespace ArtisanBuild\Docsidian;
 use ArtisanBuild\Docsidian\Actions\DoNotIndexForSearch;
 use ArtisanBuild\Docsidian\Actions\GetDefinedAbilities;
 use ArtisanBuild\Docsidian\Actions\HighlightCodeWithTempest;
+use ArtisanBuild\Docsidian\Commands\DiscoverCommand;
 use ArtisanBuild\Docsidian\Commands\GenerateCommand;
 use ArtisanBuild\Docsidian\Commands\InstallCommand;
 use ArtisanBuild\Docsidian\Contracts\HighlightsCodeBlocks;
 use ArtisanBuild\Docsidian\Contracts\IndexesSiteForSearch;
+use ArtisanBuild\Docsidian\Models\DocsidianSite;
+use Filament\Facades\Filament;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
 use Laravel\Folio\Folio;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -30,14 +35,22 @@ class DocsidianServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasViews()
             ->hasMigration('create_docsidian_table')
-            ->hasCommand(InstallCommand::class)
-            ->hasCommand(GenerateCommand::class);
+            ->hasCommands([
+                InstallCommand::class,
+                GenerateCommand::class,
+                DiscoverCommand::class,
+            ]);
     }
 
     public function registeringPackage()
     {
         $this->app->bind(IndexesSiteForSearch::class, DoNotIndexForSearch::class);
         $this->app->bind(HighlightsCodeBlocks::class, HighlightCodeWithTempest::class);
+
+        if (class_exists(Filament::class)) {
+            $this->app->register(\ArtisanBuild\Docsidian\DocumentationPanelProvider::class);
+        }
+
     }
 
     public function packageBooted(): void
@@ -46,12 +59,16 @@ class DocsidianServiceProvider extends PackageServiceProvider
             return;
         }
 
+        if (! Schema::hasTable('docsidian_sites')) {
+            return;
+        }
+
         Blade::component(DocsidianLayoutComponent::class, 'docsidian');
 
-        foreach (config('docsidian.sites') as $site) {
-            Folio::path($site['folio_path'])
-                ->uri($site['folio_uri'])
-                ->middleware($site['folio_middleware']);
+        foreach (DocsidianSite::all() as $site) {
+            Folio::path($site->folio_path)
+                ->uri($site->folio_uri)
+                ->middleware($site->folio_middleware);
         }
 
         if (app(GetDefinedAbilities::class)()->isEmpty()) {
@@ -59,6 +76,5 @@ class DocsidianServiceProvider extends PackageServiceProvider
             Gate::define('docsidian-protected', fn (?Authenticatable $user) => $user instanceof Authenticatable);
             Gate::define('docsidian-private', fn (?Authenticatable $user) => false);
         }
-
     }
 }

--- a/src/DocumentationPanelProvider.php
+++ b/src/DocumentationPanelProvider.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace ArtisanBuild\Docsidian;
+
+use Filament\Http\Middleware\Authenticate;
+use Filament\Http\Middleware\DisableBladeIconComponents;
+use Filament\Http\Middleware\DispatchServingFilamentEvent;
+use Filament\Pages;
+use Filament\Panel;
+use Filament\PanelProvider;
+use Filament\Support\Colors\Color;
+use Filament\Widgets;
+use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Routing\Middleware\SubstituteBindings;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Session\Middleware\StartSession;
+use Illuminate\View\Middleware\ShareErrorsFromSession;
+
+class DocumentationPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->default()
+            ->id('docsidian')
+            ->path('docsidian')
+            ->login()
+            ->colors([
+                'primary' => Color::Amber,
+            ])
+            ->discoverResources(in: __DIR__.'/Filament', for: 'ArtisanBuild\\Docsidian\\Filament')
+            ->discoverPages(in: __DIR__.'Filament/Pages', for: 'ArtisanBuild\\Docsidian\\Filament\\Pages')
+            ->pages([
+                Pages\Dashboard::class,
+                Pages\Dashboard::class,
+            ])
+            ->discoverWidgets(in: __DIR__.'Filament/Widgets', for: 'ArtisanBuild\\Docsidian\\Filament\\Widgets')
+            ->widgets([
+                Widgets\AccountWidget::class,
+                Widgets\FilamentInfoWidget::class,
+            ])
+            ->middleware([
+                EncryptCookies::class,
+                AddQueuedCookiesToResponse::class,
+                StartSession::class,
+                AuthenticateSession::class,
+                ShareErrorsFromSession::class,
+                VerifyCsrfToken::class,
+                SubstituteBindings::class,
+                DisableBladeIconComponents::class,
+                DispatchServingFilamentEvent::class,
+            ])
+            ->authMiddleware([
+                Authenticate::class,
+            ]);
+
+    }
+}

--- a/src/Filament/Resources/DocsidianSiteResource.php
+++ b/src/Filament/Resources/DocsidianSiteResource.php
@@ -41,7 +41,7 @@ class DocsidianSiteResource extends Resource
                 Tables\Columns\TextColumn::make('weight'),
                 Tables\Columns\TextColumn::make('name'),
                 // TODO: I shouldn't have to do this. The casting should work.
-                Tables\Columns\TextColumn::make('status')->getStateUsing(fn($record) => $record->status->name),
+                Tables\Columns\TextColumn::make('status')->getStateUsing(fn ($record) => $record->status->name),
             ])
             ->filters([
                 //

--- a/src/Filament/Resources/DocsidianSiteResource.php
+++ b/src/Filament/Resources/DocsidianSiteResource.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Filament\Resources;
+
+use ArtisanBuild\Docsidian\Models\DocsidianSite;
+use ArtisanBuild\Docsidian\SiteStatus;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class DocsidianSiteResource extends Resource
+{
+    protected static ?string $model = DocsidianSite::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Forms\Components\TextInput::make('name'),
+                Forms\Components\TextInput::make('weight')->numeric(),
+                Forms\Components\TextInput::make('description'),
+                Forms\Components\FileUpload::make('image')->image(),
+
+                Forms\Components\Select::make('status')->options(SiteStatus::class),
+
+                Forms\Components\TextInput::make('folio_uri')->columnSpanFull(),
+                Forms\Components\TextInput::make('folio_path')->columnSpanFull(),
+                Forms\Components\TextInput::make('md_path')->columnSpanFull(),
+
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('weight'),
+                Tables\Columns\TextColumn::make('name'),
+                // TODO: I shouldn't have to do this. The casting should work.
+                Tables\Columns\TextColumn::make('status')->getStateUsing(fn($record) => $record->status->name),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ])->defaultSort('weight');
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => \ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource\Pages\ListDocsidianSites::route('/'),
+            'create' => \ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource\Pages\CreateDocsidianSite::route('/create'),
+            'edit' => \ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource\Pages\EditDocsidianSite::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/Resources/DocsidianSiteResource/Pages/CreateDocsidianSite.php
+++ b/src/Filament/Resources/DocsidianSiteResource/Pages/CreateDocsidianSite.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource\Pages;
+
+use ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateDocsidianSite extends CreateRecord
+{
+    protected static string $resource = DocsidianSiteResource::class;
+}

--- a/src/Filament/Resources/DocsidianSiteResource/Pages/EditDocsidianSite.php
+++ b/src/Filament/Resources/DocsidianSiteResource/Pages/EditDocsidianSite.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource\Pages;
+
+use ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDocsidianSite extends EditRecord
+{
+    protected static string $resource = DocsidianSiteResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/Resources/DocsidianSiteResource/Pages/ListDocsidianSites.php
+++ b/src/Filament/Resources/DocsidianSiteResource/Pages/ListDocsidianSites.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource\Pages;
+
+use ArtisanBuild\Docsidian\Filament\Resources\DocsidianSiteResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDocsidianSites extends ListRecords
+{
+    protected static string $resource = DocsidianSiteResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/src/Models/DocsidianPage.php
+++ b/src/Models/DocsidianPage.php
@@ -10,9 +10,4 @@ class DocsidianPage extends Model
 {
     use HasFactory;
     use Searchable;
-
-
-
-
-
 }

--- a/src/Models/DocsidianPage.php
+++ b/src/Models/DocsidianPage.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Laravel\Scout\Searchable;
+
+class DocsidianPage extends Model
+{
+    use HasFactory;
+    use Searchable;
+
+
+
+
+
+}

--- a/src/Models/DocsidianSite.php
+++ b/src/Models/DocsidianSite.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace ArtisanBuild\Docsidian\Models;
+
+use ArtisanBuild\Docsidian\SiteStatus;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/** @mixin \Eloquent */
+class DocsidianSite extends Model
+{
+    use HasFactory;
+
+    protected $guarded = [];
+
+    protected $casts = [
+        'folio_middleware' => 'array',
+        'status' => SiteStatus::class,
+    ];
+}

--- a/src/SiteStatus.php
+++ b/src/SiteStatus.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace ArtisanBuild\Docsidian;
+
+enum SiteStatus
+{
+    case Published;
+    case Hidden;
+    case Archived;
+}


### PR DESCRIPTION
In order to make this searchable, we need to put it into a database. So I've kind of handled that. But more importantly, I've moved the "administrative" piece of it into the database and put a Filament table in front of it. Here are a few questionable decisions I made along the way:

1. I am (for now) just casting the "site" record as an array so I can keep using the exact same structure as I originally used fo the `Generate` command. I definitely need to do a full refactor to use the model properties instead.
2. I built a quick and dirty Filament table and form that I'll use for administering these sites, but I'm not sure whether I want to force users to use Filament if they're using the open-source package. It's definitely how we will deliver administration on the hosted version, but I'm trying to keep the open source piece as thin as possible. So I'm only loading the Filament panel's service provider if the Filament facade exists (implying Filmanet is installed). I'd like to come up with a cleaner, more consistent way to check for dependencies.

A weird "bug" I think I've encountered is that in the Filament table, I'm forced to reach into the status enum to get the name of the instance because apparently the casting doesn't work in that context as I'd expect it to. This might be something I missed or it might be something worthy of a PR to Filament.

I'm not going to merge this in until I've done the refactor to use the model properties instead of casting it to an array in the generation and then I need to think about whether it makes sense to get rid of the `DocumentationPage` and `DocumentationSite` classes I'm currently using in favor of just fattening up their respective Eloquent models. That's a decision for another day, and likely another PR.